### PR TITLE
Issue 17 proto object to covjson conversion unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - "**"
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Comment coverage
         uses: MishaKav/pytest-coverage-comment@main
         with:
-          pytest-coverage-path: ./pytest-coverage.txt
+          pytest-coverage-path: ./api/pytest-coverage.txt
           coverage-path-prefix: api/
           title: API Unit Test Coverage Report
           hide-badge: true
@@ -151,7 +151,7 @@ jobs:
           hide-comment: false
           report-only-changed-files: false
           remove-link-from-badge: false
-          junitxml-path: ./pytest.xml
+          junitxml-path: ./api/pytest.xml
           junitxml-title: API Unit Test Coverage Summary
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,59 @@ jobs:
         if: always()
         run: docker compose down --volumes
 
+  test-api:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Python Setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest-timeout
+          pip install pytest-cov
+          pip install -r ./api/requirements.txt
+
+      - name: Copy Protobuf file to api directory and build
+        run: |
+          mkdir ./api/protobuf
+          cp ./protobuf/datastore.proto ./api/protobuf/datastore.proto
+          python -m grpc_tools.protoc --proto_path=./api/protobuf --python_out=./api --grpc_python_out=./api ./api/protobuf/datastore.proto
+
+      - name: Run Tests
+        run: |
+          cd api
+          python -m pytest --timeout=60 --junitxml=pytest.xml --cov-report=term-missing --cov=. | tee pytest-coverage.txt
+
+      - name: Comment coverage
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: ./pytest-coverage.txt
+          coverage-path-prefix: api/
+          title: API Unit Test Coverage Report
+          hide-badge: true
+          hide-report: false
+          create-new-comment: false
+          hide-comment: false
+          report-only-changed-files: false
+          remove-link-from-badge: false
+          junitxml-path: ./pytest.xml
+          junitxml-title: API Unit Test Coverage Summary
+
+
 # TODO: These tests don't currently work. Uncomment once this is resolved.
 #  test-ingest:
 #    runs-on: ubuntu-latest

--- a/api/test/test_covjson.py
+++ b/api/test/test_covjson.py
@@ -2,6 +2,7 @@ import json
 
 import datastore_pb2 as dstore
 from covjson_pydantic.coverage import Coverage
+from covjson_pydantic.coverage import CoverageCollection
 from formatters.covjson import Covjson
 from google.protobuf.json_format import Parse
 
@@ -55,6 +56,31 @@ def test_multiple_parameter_convert():
     assert 230.7 in coverage_collection.ranges["dd"].values
     assert 9.19 in coverage_collection.ranges["ff"].values
     assert 88.0 in coverage_collection.ranges["rh"].values
+
+    # TODO: Modify compare data when parameter names have been decided
+    coverage_collection_json = json.loads(coverage_collection.model_dump_json(exclude_none=True))
+    assert coverage_collection_json == compare_data
+
+
+def test_single_parameter_area_convert():
+    test_data = load_json("test/test_data/test_coverages_proto.json")
+    compare_data = load_json("test/test_data/test_coverages_covjson.json")
+
+    response = create_mock_obs_response(test_data)
+
+    coverage_collection = Covjson().convert(response)
+
+    assert coverage_collection is not None
+
+    assert type(coverage_collection) is CoverageCollection
+
+    assert len(coverage_collection.coverages) > 1
+
+    assert all([type(coverage) is Coverage for coverage in coverage_collection.coverages])
+
+    # Check that each coverage has the correct parameter
+    # TODO: Change parameter name when parameter names have been decided
+    assert all(["TA_P1D_AVG" in coverage.parameters.keys() for coverage in coverage_collection.coverages])
 
     # TODO: Modify compare data when parameter names have been decided
     coverage_collection_json = json.loads(coverage_collection.model_dump_json(exclude_none=True))

--- a/api/test/test_covjson.py
+++ b/api/test/test_covjson.py
@@ -35,6 +35,32 @@ def test_single_parameter_convert():
     assert coverage_collection_json == compare_data
 
 
+def test_multiple_parameter_convert():
+    test_data = load_json("test/test_data/test_multiple_proto.json")
+    compare_data = load_json("test/test_data/test_multiple_covjson.json")
+
+    response = create_mock_obs_response(test_data)
+
+    coverage_collection = Covjson().convert(response)
+
+    assert coverage_collection is not None
+
+    assert type(coverage_collection) is Coverage
+
+    # Check that the coverage collection has the correct parameters
+    # TODO: Change parameter names when parameter names have been decided
+    assert set(["dd", "ff", "rh"]) == coverage_collection.parameters.keys()
+
+    # Check that correct values exist in the coverage collection
+    assert 230.7 in coverage_collection.ranges["dd"].values
+    assert 9.19 in coverage_collection.ranges["ff"].values
+    assert 88.0 in coverage_collection.ranges["rh"].values
+
+    # TODO: Modify compare data when parameter names have been decided
+    coverage_collection_json = json.loads(coverage_collection.model_dump_json(exclude_none=True))
+    assert coverage_collection_json == compare_data
+
+
 def create_mock_obs_response(json_data):
     response = dstore.GetObsResponse()
     Parse(json.dumps(json_data), response)

--- a/api/test/test_covjson.py
+++ b/api/test/test_covjson.py
@@ -1,8 +1,10 @@
 import json
 
 import datastore_pb2 as dstore
+import pytest
 from covjson_pydantic.coverage import Coverage
 from covjson_pydantic.coverage import CoverageCollection
+from fastapi import HTTPException
 from formatters.covjson import Covjson
 from google.protobuf.json_format import Parse
 
@@ -85,6 +87,19 @@ def test_single_parameter_area_convert():
     # TODO: Modify compare data when parameter names have been decided
     coverage_collection_json = json.loads(coverage_collection.model_dump_json(exclude_none=True))
     assert coverage_collection_json == compare_data
+
+
+def test_empty_response_convert():
+    test_data = load_json("test/test_data/test_empty_proto.json")
+    response = create_mock_obs_response(test_data)
+
+    # Expect to get an HTTPException with status code of 404 and detail of
+    # "No data found" when converting an empty response
+    with pytest.raises(HTTPException) as exception_info:
+        Covjson().convert(response)
+
+    assert exception_info.value.detail == "No data found"
+    assert exception_info.value.status_code == 404
 
 
 def create_mock_obs_response(json_data):

--- a/api/test/test_data/test_coverages_covjson.json
+++ b/api/test/test_data/test_coverages_covjson.json
@@ -1,0 +1,178 @@
+{
+    "type": "CoverageCollection",
+    "coverages": [
+        {
+            "type": "Coverage",
+            "domain": {
+                "type": "Domain",
+                "domainType": "PointSeries",
+                "axes": {
+                    "x": {
+                        "values": [
+                            22.19342704
+                        ]
+                    },
+                    "y": {
+                        "values": [
+                            59.86948983
+                        ]
+                    },
+                    "t": {
+                        "values": [
+                            "2022-12-31T00:00:00Z"
+                        ]
+                    }
+                },
+                "referencing": [
+                    {
+                        "coordinates": [
+                            "y",
+                            "x"
+                        ],
+                        "system": {
+                            "type": "GeographicCRS",
+                            "id": "http://www.opengis.net/def/crs/EPSG/0/4326"
+                        }
+                    },
+                    {
+                        "coordinates": [
+                            "z"
+                        ],
+                        "system": {
+                            "type": "TemporalRS",
+                            "calendar": "Gregorian"
+                        }
+                    }
+                ]
+            },
+            "parameters": {
+                "TA_P1D_AVG": {
+                    "type": "Parameter",
+                    "observedProperty": {
+                        "label": {
+                            "en": "TA_P1D_AVG"
+                        }
+                    },
+                    "unit": {
+                        "label": {
+                            "en": "degC"
+                        }
+                    }
+                }
+            },
+            "ranges": {
+                "TA_P1D_AVG": {
+                    "type": "NdArray",
+                    "dataType": "float",
+                    "axisNames": [
+                        "t",
+                        "y",
+                        "x"
+                    ],
+                    "shape": [
+                        1,
+                        1,
+                        1
+                    ],
+                    "values": [
+                        5.2
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Coverage",
+            "domain": {
+                "type": "Domain",
+                "domainType": "PointSeries",
+                "axes": {
+                    "x": {
+                        "values": [
+                            24.3986218
+                        ]
+                    },
+                    "y": {
+                        "values": [
+                            60.41875496
+                        ]
+                    },
+                    "t": {
+                        "values": [
+                            "2022-12-31T00:00:00Z"
+                        ]
+                    }
+                },
+                "referencing": [
+                    {
+                        "coordinates": [
+                            "y",
+                            "x"
+                        ],
+                        "system": {
+                            "type": "GeographicCRS",
+                            "id": "http://www.opengis.net/def/crs/EPSG/0/4326"
+                        }
+                    },
+                    {
+                        "coordinates": [
+                            "z"
+                        ],
+                        "system": {
+                            "type": "TemporalRS",
+                            "calendar": "Gregorian"
+                        }
+                    }
+                ]
+            },
+            "parameters": {
+                "TA_P1D_AVG": {
+                    "type": "Parameter",
+                    "observedProperty": {
+                        "label": {
+                            "en": "TA_P1D_AVG"
+                        }
+                    },
+                    "unit": {
+                        "label": {
+                            "en": "degC"
+                        }
+                    }
+                }
+            },
+            "ranges": {
+                "TA_P1D_AVG": {
+                    "type": "NdArray",
+                    "dataType": "float",
+                    "axisNames": [
+                        "t",
+                        "y",
+                        "x"
+                    ],
+                    "shape": [
+                        1,
+                        1,
+                        1
+                    ],
+                    "values": [
+                        3.7
+                    ]
+                }
+            }
+        }
+    ],
+    "parameters": {
+        "TA_P1D_AVG": {
+            "type": "Parameter",
+            "observedProperty": {
+                "label": {
+                    "en": "TA_P1D_AVG"
+                }
+            },
+            "unit": {
+                "label": {
+                    "en": "degC"
+                }
+            }
+        }
+    }
+}

--- a/api/test/test_data/test_coverages_proto.json
+++ b/api/test/test_data/test_coverages_proto.json
@@ -1,0 +1,46 @@
+{
+    "observations": [
+        {
+            "ts_mdata": {
+                "title": "FMI test data",
+                "platform": "100945",
+                "standard_name": "TA_P1D_AVG",
+                "unit": "degC",
+                "instrument": "TA_P1D_AVG"
+            },
+            "obs_mdata": [
+                {
+                    "id": "56513647-809c-4582-94c1-40afeff639f8",
+                    "geo_point": {
+                        "lat": 59.86948983,
+                        "lon": 22.19342704
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:00:00Z",
+                    "value": "5.2"
+                }
+            ]
+        },
+        {
+            "ts_mdata": {
+                "title": "FMI test data",
+                "platform": "100976",
+                "standard_name": "TA_P1D_AVG",
+                "unit": "degC",
+                "instrument": "TA_P1D_AVG"
+            },
+            "obs_mdata": [
+                {
+                    "id": "7a144238-1c53-43de-b03e-9a630a89051f",
+                    "geo_point": {
+                        "lat": 60.41875496,
+                        "lon": 24.3986218
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:00:00Z",
+                    "value": "3.7"
+                }
+            ]
+        }
+    ]
+}

--- a/api/test/test_data/test_empty_proto.json
+++ b/api/test/test_data/test_empty_proto.json
@@ -1,0 +1,3 @@
+{
+    "observations": []
+}

--- a/api/test/test_data/test_multiple_covjson.json
+++ b/api/test/test_data/test_multiple_covjson.json
@@ -1,0 +1,147 @@
+{
+    "type": "Coverage",
+    "domain": {
+        "type": "Domain",
+        "domainType": "PointSeries",
+        "axes": {
+            "x": {
+                "values": [
+                    6.5848470019087
+                ]
+            },
+            "y": {
+                "values": [
+                    53.123676213651
+                ]
+            },
+            "t": {
+                "values": [
+                    "2022-12-31T00:00:00Z",
+                    "2022-12-31T00:10:00Z",
+                    "2022-12-31T00:20:00Z"
+                ]
+            }
+        },
+        "referencing": [
+            {
+                "coordinates": [
+                    "y",
+                    "x"
+                ],
+                "system": {
+                    "type": "GeographicCRS",
+                    "id": "http://www.opengis.net/def/crs/EPSG/0/4326"
+                }
+            },
+            {
+                "coordinates": [
+                    "z"
+                ],
+                "system": {
+                    "type": "TemporalRS",
+                    "calendar": "Gregorian"
+                }
+            }
+        ]
+    },
+    "parameters": {
+        "dd": {
+            "type": "Parameter",
+            "observedProperty": {
+                "label": {
+                    "en": "dd"
+                }
+            },
+            "unit": {
+                "label": {
+                    "en": "degree"
+                }
+            }
+        },
+        "ff": {
+            "type": "Parameter",
+            "observedProperty": {
+                "label": {
+                    "en": "ff"
+                }
+            },
+            "unit": {
+                "label": {
+                    "en": "m s-1"
+                }
+            }
+        },
+        "rh": {
+            "type": "Parameter",
+            "observedProperty": {
+                "label": {
+                    "en": "rh"
+                }
+            },
+            "unit": {
+                "label": {
+                    "en": "%"
+                }
+            }
+        }
+    },
+    "ranges": {
+        "dd": {
+            "type": "NdArray",
+            "dataType": "float",
+            "axisNames": [
+                "t",
+                "y",
+                "x"
+            ],
+            "shape": [
+                3,
+                1,
+                1
+            ],
+            "values": [
+                226.7,
+                230.7,
+                232.9
+            ]
+        },
+        "ff": {
+            "type": "NdArray",
+            "dataType": "float",
+            "axisNames": [
+                "t",
+                "y",
+                "x"
+            ],
+            "shape": [
+                3,
+                1,
+                1
+            ],
+            "values": [
+                9.71,
+                9.32,
+                9.19
+            ]
+        },
+        "rh": {
+            "type": "NdArray",
+            "dataType": "float",
+            "axisNames": [
+                "t",
+                "y",
+                "x"
+            ],
+            "shape": [
+                3,
+                1,
+                1
+            ],
+            "values": [
+                88,
+                88,
+                88
+            ]
+        }
+    }
+}

--- a/api/test/test_data/test_multiple_proto.json
+++ b/api/test/test_data/test_multiple_proto.json
@@ -1,0 +1,127 @@
+{
+    "observations": [
+        {
+            "ts_mdata": {
+                "title": "Wind Speed at 10m 10 Min Average",
+                "platform": "06280",
+                "standard_name": "wind_speed",
+                "unit": "m s-1",
+                "instrument": "ff"
+            },
+            "obs_mdata": [
+                {
+                    "id": "af50a680-d84a-41bb-a85f-4803dcd5d4b5",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:00:00Z",
+                    "value": "9.71"
+                },
+                {
+                    "id": "f236836d-5523-4609-9bfc-73158865076c",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:10:00Z",
+                    "value": "9.32"
+                },
+                {
+                    "id": "4b2eaa2e-1850-43f6-b844-ba4461c14d46",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:20:00Z",
+                    "value": "9.19"
+                }
+            ]
+        },
+        {
+            "ts_mdata": {
+                "title": "Wind Direction 10 Min Average",
+                "platform": "06280",
+                "standard_name": "wind_from_direction",
+                "unit": "degree",
+                "instrument": "dd"
+            },
+            "obs_mdata": [
+                {
+                    "id": "f7ec5d92-f3ab-4524-ad4e-a777a05b3b68",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:00:00Z",
+                    "value": "226.7"
+                },
+                {
+                    "id": "12bebe9e-1ddd-46cf-b9fa-2f866e987683",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:10:00Z",
+                    "value": "230.7"
+                },
+                {
+                    "id": "106f74e3-233a-46e3-83d4-b8508eb77aaf",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:20:00Z",
+                    "value": "232.9"
+                }
+            ]
+        },
+        {
+            "ts_mdata": {
+                "title": "Relative Humidity 1 Min Average",
+                "platform": "06280",
+                "standard_name": "relative_humidity",
+                "unit": "%",
+                "instrument": "rh"
+            },
+            "obs_mdata": [
+                {
+                    "id": "8319d5a3-1ae9-4dc1-a83e-1548acd7b1b3",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:00:00Z",
+                    "value": "88.0"
+                },
+                {
+                    "id": "dc714268-8a24-4527-bed9-ea1e20d0568e",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:10:00Z",
+                    "value": "88.0"
+                },
+                {
+                    "id": "e2f7e423-23e7-4270-ae8c-6c7f769f3098",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:20:00Z",
+                    "value": "88.0"
+                }
+            ]
+        }
+    ]
+}

--- a/api/test/test_data/test_single_covjson.json
+++ b/api/test/test_data/test_single_covjson.json
@@ -1,0 +1,91 @@
+{
+    "type": "Coverage",
+    "domain": {
+        "type": "Domain",
+        "domainType": "PointSeries",
+        "axes": {
+            "x": {
+                "values": [
+                    6.5848470019087
+                ]
+            },
+            "y": {
+                "values": [
+                    53.123676213651
+                ]
+            },
+            "t": {
+                "values": [
+                    "2022-12-31T00:00:00Z",
+                    "2022-12-31T00:10:00Z",
+                    "2022-12-31T00:20:00Z",
+                    "2022-12-31T00:30:00Z",
+                    "2022-12-31T00:40:00Z",
+                    "2022-12-31T00:50:00Z",
+                    "2022-12-31T01:00:00Z"
+                ]
+            }
+        },
+        "referencing": [
+            {
+                "coordinates": [
+                    "y",
+                    "x"
+                ],
+                "system": {
+                    "type": "GeographicCRS",
+                    "id": "http://www.opengis.net/def/crs/EPSG/0/4326"
+                }
+            },
+            {
+                "coordinates": [
+                    "z"
+                ],
+                "system": {
+                    "type": "TemporalRS",
+                    "calendar": "Gregorian"
+                }
+            }
+        ]
+    },
+    "parameters": {
+        "ff": {
+            "type": "Parameter",
+            "observedProperty": {
+                "label": {
+                    "en": "ff"
+                }
+            },
+            "unit": {
+                "label": {
+                    "en": "m s-1"
+                }
+            }
+        }
+    },
+    "ranges": {
+        "ff": {
+            "type": "NdArray",
+            "dataType": "float",
+            "axisNames": [
+                "t",
+                "y",
+                "x"
+            ],
+            "shape": [
+                7,
+                1,
+                1
+            ],
+            "values": [
+                9.71,
+                9.32,
+                9.19,
+                9.21,
+                8.7,
+                8.12,
+                7.28
+            ]
+        }
+    }
+}

--- a/api/test/test_data/test_single_proto.json
+++ b/api/test/test_data/test_single_proto.json
@@ -1,0 +1,85 @@
+{
+    "observations": [
+        {
+            "ts_mdata": {
+                "title": "Wind Speed at 10m 10 Min Average",
+                "platform": "06280",
+                "standard_name": "wind_speed",
+                "unit": "m s-1",
+                "instrument": "ff"
+            },
+            "obs_mdata": [
+                {
+                    "id": "af50a680-d84a-41bb-a85f-4803dcd5d4b5",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:00:00Z",
+                    "value": "9.71"
+                },
+                {
+                    "id": "f236836d-5523-4609-9bfc-73158865076c",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:10:00Z",
+                    "value": "9.32"
+                },
+                {
+                    "id": "4b2eaa2e-1850-43f6-b844-ba4461c14d46",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:20:00Z",
+                    "value": "9.19"
+                },
+                {
+                    "id": "d3ee45d7-b7b7-419a-9bf5-77699c70894d",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:30:00Z",
+                    "value": "9.21"
+                },
+                {
+                    "id": "5232105a-ceb4-4ea5-9957-78f730f9f51d",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:40:00Z",
+                    "value": "8.7"
+                },
+                {
+                    "id": "bbb5733e-7598-4ba7-ba68-3462ee3df8cd",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T00:50:00Z",
+                    "value": "8.12"
+                },
+                {
+                    "id": "5a1157d9-bf37-4696-8068-ac5f15163a4f",
+                    "geo_point": {
+                        "lat": 53.123676213651,
+                        "lon": 6.5848470019087
+                    },
+                    "pubtime": "1970-01-01T00:00:00Z",
+                    "obstime_instant": "2022-12-31T01:00:00Z",
+                    "value": "7.28"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Closes #17

- Adds unit tests to  protobuf to coverageJson formatter
  - Test cases for different conversions mocking the gRPC response and checking the conversion against known conversion results
- Update Github Actions to run api unit tests on push
  - Post coverage to pull request comment or push commit depending on action 