### PR TITLE
Issue 18 functionality to return all parameters when parameter-names are not given

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           pip install --upgrade pip
           pip install pytest-timeout
           pip install pytest-cov
+          pip install httpx
           pip install -r ./api/requirements.txt
 
       - name: Copy Protobuf file to api directory and build

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from datetime import timedelta
 from typing import Tuple
 
+from fastapi import HTTPException
 from google.protobuf.timestamp_pb2 import Timestamp
 from pydantic import AwareDatetime
 from pydantic import TypeAdapter
@@ -11,23 +12,38 @@ def get_datetime_range(datetime_string: str | None) -> Tuple[Timestamp, Timestam
     if not datetime_string:
         return None
 
+    errors = {}
+
     start_datetime, end_datetime = Timestamp(), Timestamp()
     aware_datetime_type_adapter = TypeAdapter(AwareDatetime)
-    datetimes = tuple(value.strip() for value in datetime_string.split("/"))
-    if len(datetimes) == 1:
-        start_datetime.FromDatetime(aware_datetime_type_adapter.validate_python(datetimes[0]))
-        end_datetime.FromDatetime(
-            aware_datetime_type_adapter.validate_python(datetimes[0]) + timedelta(seconds=1)
-        )  # HACK: Add one second so we get some data, as the store returns [start, end)
-    else:
-        if datetimes[0] != "..":
+
+    try:
+        datetimes = tuple(value.strip() for value in datetime_string.split("/"))
+        if len(datetimes) == 1:
             start_datetime.FromDatetime(aware_datetime_type_adapter.validate_python(datetimes[0]))
+            end_datetime.FromDatetime(
+                aware_datetime_type_adapter.validate_python(datetimes[0]) + timedelta(seconds=1)
+            )  # HACK: Add one second so we get some data, as the store returns [start, end)
         else:
-            start_datetime.FromDatetime(datetime.min)
-        if datetimes[1] != "..":
-            # HACK add one second so that the end_datetime is included in the interval.
-            end_datetime.FromDatetime(aware_datetime_type_adapter.validate_python(datetimes[1]) + timedelta(seconds=1))
-        else:
-            end_datetime.FromDatetime(datetime.max)
+            if datetimes[0] != "..":
+                start_datetime.FromDatetime(aware_datetime_type_adapter.validate_python(datetimes[0]))
+            else:
+                start_datetime.FromDatetime(datetime.min)
+            if datetimes[1] != "..":
+                # HACK add one second so that the end_datetime is included in the interval.
+                end_datetime.FromDatetime(
+                    aware_datetime_type_adapter.validate_python(datetimes[1]) + timedelta(seconds=1)
+                )
+            else:
+                end_datetime.FromDatetime(datetime.max)
+
+            if start_datetime.seconds > end_datetime.seconds:
+                errors["datetime"] = f"Invalid range: {datetimes[0]} > {datetimes[1]}"
+
+    except ValueError:
+        errors["datetime"] = f"Invalid format: {datetime_string}"
+
+    if errors:
+        raise HTTPException(status_code=422, detail=errors)
 
     return start_datetime, end_datetime

--- a/api/routers/edr.py
+++ b/api/routers/edr.py
@@ -62,7 +62,7 @@ async def get_locations(bbox: str = Query(..., example="5.0,52.0,6.0,52.1")) -> 
 async def get_data_location_id(
     location_id: str = Path(..., example="06260"),
     parameter_name: str = Query(None, alias="parameter-name", example="dd,ff,rh,pp,tn"),
-    datetime: str | None = None,
+    datetime: str = Query(None, example="2022-12-31T00:00Z/2023-01-01T00:00Z"),
     f: str = Query(default="covjson", alias="f", description="Specify return format."),
 ):
     # TODO: There is no error handling of any kind at the moment!
@@ -90,7 +90,7 @@ async def get_data_location_id(
 async def get_data_position(
     coords: str = Query(..., example="POINT(5.179705 52.0988218)"),
     parameter_name: str = Query(None, alias="parameter-name", example="dd,ff,rh,pp,tn"),
-    datetime: str | None = None,
+    datetime: str = Query(None, example="2022-12-31T00:00Z/2023-01-01T00:00Z"),
     f: str = Query(default="covjson", alias="f", description="Specify return format."),
 ):
     point = wkt.loads(coords)
@@ -108,7 +108,7 @@ async def get_data_position(
 async def get_data_area(
     coords: str = Query(..., example="POLYGON((5.0 52.0, 6.0 52.0,6.0 52.1,5.0 52.1, 5.0 52.0))"),
     parameter_name: str = Query(None, alias="parameter-name", example="dd,ff,rh,pp,tn"),
-    datetime: str | None = None,
+    datetime: str = Query(None, example="2022-12-31T00:00Z/2023-01-01T00:00Z"),
     f: str = Query(default="covjson", alias="f", description="Specify return format."),
 ):
     poly = wkt.loads(coords)

--- a/api/routers/edr.py
+++ b/api/routers/edr.py
@@ -56,12 +56,12 @@ async def get_locations(bbox: str = Query(..., example="5.0,52.0,6.0,52.1")) -> 
 @router.get(
     "/locations/{location_id}",
     tags=["Collection data queries"],
-    response_model=Coverage,
+    response_model=Coverage | CoverageCollection,
     response_model_exclude_none=True,
 )
 async def get_data_location_id(
     location_id: str = Path(..., example="06260"),
-    parameter_name: str = Query(..., alias="parameter-name", example="dd,ff,rh,pp,tn"),
+    parameter_name: str = Query(None, alias="parameter-name", example="dd,ff,rh,pp,tn"),
     datetime: str | None = None,
     f: str = Query(default="covjson", alias="f", description="Specify return format."),
 ):
@@ -71,7 +71,9 @@ async def get_data_location_id(
     get_obs_request = dstore.GetObsRequest(
         filter=dict(
             platform=dstore.Strings(values=[location_id]),
-            instrument=dstore.Strings(values=list(map(str.strip, parameter_name.split(",")))),
+            instrument=dstore.Strings(
+                values=list(map(str.strip, parameter_name.split(","))) if parameter_name else "*"
+            ),
         ),
         interval=dstore.TimeInterval(start=range[0], end=range[1]) if range else None,
     )

--- a/api/routers/edr.py
+++ b/api/routers/edr.py
@@ -89,7 +89,7 @@ async def get_data_location_id(
 )
 async def get_data_position(
     coords: str = Query(..., example="POINT(5.179705 52.0988218)"),
-    parameter_name: str = Query(..., alias="parameter-name", example="dd,ff,rh,pp,tn"),
+    parameter_name: str = Query(None, alias="parameter-name", example="dd,ff,rh,pp,tn"),
     datetime: str | None = None,
     f: str = Query(default="covjson", alias="f", description="Specify return format."),
 ):
@@ -107,7 +107,7 @@ async def get_data_position(
 )
 async def get_data_area(
     coords: str = Query(..., example="POLYGON((5.0 52.0, 6.0 52.0,6.0 52.1,5.0 52.1, 5.0 52.0))"),
-    parameter_name: str = Query(..., alias="parameter-name", example="dd,ff,rh,pp,tn"),
+    parameter_name: str = Query(None, alias="parameter-name", example="dd,ff,rh,pp,tn"),
     datetime: str | None = None,
     f: str = Query(default="covjson", alias="f", description="Specify return format."),
 ):
@@ -115,7 +115,9 @@ async def get_data_area(
     assert poly.geom_type == "Polygon"
     range = get_datetime_range(datetime)
     get_obs_request = dstore.GetObsRequest(
-        filter=dict(instrument=dstore.Strings(values=list(map(str.strip, parameter_name.split(","))))),
+        filter=dict(
+            instrument=dstore.Strings(values=list(map(str.strip, parameter_name.split(","))) if parameter_name else "*")
+        ),
         inside=dstore.Polygon(points=[dstore.Point(lat=coord[1], lon=coord[0]) for coord in poly.exterior.coords]),
         interval=dstore.TimeInterval(start=range[0], end=range[1]) if range else None,
     )

--- a/api/test/test_edr.py
+++ b/api/test/test_edr.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 import datastore_pb2 as dstore
+import routers.edr as edr
 from fastapi.testclient import TestClient
 from google.protobuf.json_format import Parse
 from main import app
@@ -26,6 +27,12 @@ def test_get_locations_id_with_single_parameter_query_without_format():
         mock_getObsRequest.assert_called_once()
         assert "ff" in mock_getObsRequest.call_args[0][0].filter["instrument"].values
         assert "06260" in mock_getObsRequest.call_args[0][0].filter["platform"].values
+        assert "2022-12-31 00:00:00" == mock_getObsRequest.call_args[0][0].interval.start.ToDatetime().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        assert "2022-12-31 01:00:01" == mock_getObsRequest.call_args[0][0].interval.end.ToDatetime().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
 
         assert response.status_code == 200
         assert response.json()["type"] == "Coverage"
@@ -64,6 +71,108 @@ def test_get_locations_id_with_incorrect_datetime_range():
 
     assert response.status_code == 422
     assert response.json() == {"detail": {"datetime": "Invalid range: 2024-12-31T00:00:00Z > 2022-12-31T01:00:00Z"}}
+
+
+def test_get_locations_id_with_empty_response():
+    with patch("routers.edr.getObsRequest") as mock_getObsRequest:
+        test_data = load_json("test/test_data/test_empty_proto.json")
+
+        mock_getObsRequest.return_value = create_mock_obs_response(test_data)
+
+        response = client.get("/collections/observations/locations/10000?f=covjson")
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "No data found"}
+
+
+def test_get_area_with_normal_query():
+    with patch("routers.edr.getObsRequest") as mock_getObsRequest:
+        test_data = load_json("test/test_data/test_coverages_proto.json")
+        compare_data = load_json("test/test_data/test_coverages_covjson.json")
+
+        mock_getObsRequest.return_value = create_mock_obs_response(test_data)
+
+        response = client.get(
+            "/collections/observations/area?coords=POLYGON((22.12 59.86, 24.39 60.41, "
+            " 24.39 60.41, 24.39 59.86, 22.12 59.86))"
+            "&parameter-name=TA_P1D_AVG&datetime=2022-12-31T00:00:00Z/2022-12-31T01:00:00Z"
+        )
+
+        # Check that getObsRequest gets called with correct arguments given in query
+        mock_getObsRequest.assert_called_once()
+        assert "TA_P1D_AVG" in mock_getObsRequest.call_args[0][0].filter["instrument"].values
+        assert len(mock_getObsRequest.call_args[0][0].inside.points) == 5
+        assert 22.12 == mock_getObsRequest.call_args[0][0].inside.points[0].lon
+        assert "2022-12-31 00:00:00" == mock_getObsRequest.call_args[0][0].interval.start.ToDatetime().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        assert "2022-12-31 01:00:01" == mock_getObsRequest.call_args[0][0].interval.end.ToDatetime().strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
+        assert response.status_code == 200
+        assert response.json() == compare_data
+
+
+def test_get_area_with_incorrect_coords():
+    response = client.get("/collections/observations/area?coords=POLYGON((22.12 59.86, 24.39 60.41))")
+
+    assert response.status_code == 422
+
+
+def test_get_area_with_incorrect_geometry_type():
+    response = client.get("/collections/observations/area?coords=POINT(22.12 59.86)")
+
+    assert response.status_code == 422
+
+
+def test_get_position_with_normal_query():
+    # Wrap the original get_data_area to a mock so we can assert against the call values
+    with patch("routers.edr.get_data_area", wraps=edr.get_data_area) as mock_get_data_area, patch(
+        "routers.edr.getObsRequest"
+    ) as mock_getObsRequest:
+        test_data = load_json("test/test_data/test_coverages_proto.json")
+        compare_data = load_json("test/test_data/test_coverages_covjson.json")
+
+        mock_getObsRequest.return_value = create_mock_obs_response(test_data)
+
+        response = client.get(
+            "/collections/observations/position?coords=POINT(5.179705 52.0988218)"
+            "&parameter-name=TA_P1D_AVG&datetime=2022-12-31T00:00Z/2022-12-31T00:00Z"
+        )
+
+        mock_get_data_area.assert_called_once()
+        mock_get_data_area.assert_called_with(
+            "POLYGON ((5.179805 52.0988218, 5.179705 52.0987218, 5.1796050000000005 52.0988218, "
+            "5.179705 52.09892180000001, 5.179805 52.0988218))",
+            "TA_P1D_AVG",
+            "2022-12-31T00:00Z/2022-12-31T00:00Z",
+            "covjson",
+        )
+
+        assert response.status_code == 200
+        assert response.json() == compare_data
+
+
+def test_get_position_with_incorrect_coords():
+    response = client.get("/collections/observations/position?coords=POINT(60.41)")
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": {"coords": "Invalid coordinates: POINT(60.41)"}}
+
+
+def test_get_position_with_incorrect_geometry_type():
+    response = client.get(
+        "/collections/observations/position?coords=POLYGON((22.12 59.86, 24.39 60.41, "
+        "24.39 60.41, 24.39 59.86, 22.12 59.86))"
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": {
+            "coords": "Invalid coordinates: POLYGON((22.12 59.86, 24.39 60.41, 24.39 60.41, 24.39 59.86, 22.12 59.86))"
+        }
+    }
 
 
 def create_mock_obs_response(json_data):

--- a/api/test/test_edr.py
+++ b/api/test/test_edr.py
@@ -1,0 +1,77 @@
+import json
+from unittest.mock import patch
+
+import datastore_pb2 as dstore
+from fastapi.testclient import TestClient
+from google.protobuf.json_format import Parse
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_get_locations_id_with_single_parameter_query_without_format():
+    with patch("routers.edr.getObsRequest") as mock_getObsRequest:
+        test_data = load_json("test/test_data/test_single_proto.json")
+        compare_data = load_json("test/test_data/test_single_covjson.json")
+
+        mock_getObsRequest.return_value = create_mock_obs_response(test_data)
+
+        response = client.get(
+            "/collections/observations/locations/06260?"
+            + "parameter-name=ff&datetime=2022-12-31T00:00:00Z/2022-12-31T01:00:00Z"
+        )
+
+        # Check that getObsRequest gets called with correct arguments given in query
+        mock_getObsRequest.assert_called_once()
+        assert "ff" in mock_getObsRequest.call_args[0][0].filter["instrument"].values
+        assert "06260" in mock_getObsRequest.call_args[0][0].filter["platform"].values
+
+        assert response.status_code == 200
+        assert response.json()["type"] == "Coverage"
+        assert response.json() == compare_data
+
+
+def test_get_locations_id_without_parameter_names_query():
+    with patch("routers.edr.getObsRequest") as mock_getObsRequest:
+        test_data = load_json("test/test_data/test_multiple_proto.json")
+        compare_data = load_json("test/test_data/test_multiple_covjson.json")
+
+        mock_getObsRequest.return_value = create_mock_obs_response(test_data)
+
+        response = client.get("/collections/observations/locations/06260?f=covjson")
+
+        # Check that getObsRequest gets called with correct arguments when no parameter names are given
+        # in query
+        mock_getObsRequest.assert_called_once()
+        assert "*" in mock_getObsRequest.call_args[0][0].filter["instrument"].values
+
+        assert response.status_code == 200
+        assert response.json() == compare_data
+
+
+def test_get_locations_id_with_incorrect_datetime_format():
+    response = client.get("/collections/observations/locations/06260?datetime=20221231T000000Z/20221231T010000Z")
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": {"datetime": "Invalid format: 20221231T000000Z/20221231T010000Z"}}
+
+
+def test_get_locations_id_with_incorrect_datetime_range():
+    response = client.get(
+        "/collections/observations/locations/06260?datetime=2024-12-31T00:00:00Z/2022-12-31T01:00:00Z"
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": {"datetime": "Invalid range: 2024-12-31T00:00:00Z > 2022-12-31T01:00:00Z"}}
+
+
+def create_mock_obs_response(json_data):
+    response = dstore.GetObsResponse()
+    Parse(json.dumps(json_data), response)
+    return response
+
+
+def load_json(file_path):
+    with open(file_path, "r") as file:
+        return json.load(file)


### PR DESCRIPTION
Closes #18 

- Parameter name is no longer required in the query
  - Returns all parameters and values from /locations/{id}, /position and /area endpoints without parameter name in query
    - Returns all also when parameter-name is given, but empty string
  
- Updates Swagger documentation with examples of time date

- Improves error handling
  - Return 422 with incorrect coordinates or geometric type
  - Return 422 when time date is wrong format or start time is before end time in query

- Adds unit tests to edr api endpoints
  - Test cases with mocked functions asserting correct calls to functions
  - Test cases to check that incorrect queries returns 422 with descriptive error message