### PR TITLE
Removed obsolete comment

### DIFF
--- a/datastore/datastore/storagebackend/postgresql/getobservations.go
+++ b/datastore/datastore/storagebackend/postgresql/getobservations.go
@@ -153,9 +153,6 @@ func getTimeFilter(tspec common.TemporalSpec) string {
 	timeExpr := "TRUE" // by default, don't filter on obs time at all
 
 	if tspec.IntervalMode {
-		// the 'interval' filter is applied in the same way to all time series and can thus be
-		// part of the WHERE clause (this is contrast to the 'latest' filter which must be applied
-		// individually to each time series at a later stage)
 		ti := tspec.Interval
 		if ti != nil {
 			timeExprs := []string{}


### PR DESCRIPTION
It doesn't really make sense to have this comment here at this stage. Besides, it is obsolete since 'latest' mode doesn't currently support latest_maxage and latest_limit.