### PR TITLE
Use GetTSAGRequest() for /collections endpoint.

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,6 +12,18 @@ from fastapi import FastAPI
 from fastapi import Request
 from routers import edr  # , records
 
+
+def setup_logging():
+    logger = logging.getLogger()
+    syslog = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s ; e-soh-api ; %(process)s ; %(levelname)s ; %(name)s ; %(message)s")
+
+    syslog.setFormatter(formatter)
+    logger.addHandler(syslog)
+
+
+setup_logging()
+
 logger = logging.getLogger(__name__)
 
 app = FastAPI()

--- a/datastore/load-test/schedule_write.py
+++ b/datastore/load-test/schedule_write.py
@@ -67,6 +67,7 @@ def write_data(station):
             title=long_name,
             standard_name=standard_name,
             unit=unit,
+            parameter_name=f"{standard_name}_2.0m_{param_id}_PT10M",  # HACK: Putting {param_id} here is a hack
         )
         obs_mdata = dstore.ObsMetadata(
             id=str(uuid.uuid4()),


### PR DESCRIPTION
For the full 200K timeseries in my test for /collections, gRPC message size goes down from 44 MB to 4289 bytes. Runtime from 2250 ms to 88 ms.