### PR TITLE
Issue 73 - Clean up request filter building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Run Tests
         run: |
           cd api
-          python -m pytest --timeout=60 --junitxml=pytest.xml --cov-report=term-missing --cov=. --cov-config=test/.coveragerc | tee pytest-coverage.txt
+          python -m pytest --timeout=60 --junitxml=pytest.xml --cov-report=term-missing --cov=. --cov-config=test/.coveragerc | tee pytest-coverage.txt; exit ${PIPESTATUS[0]}
 
       - name: Comment coverage
         uses: MishaKav/pytest-coverage-comment@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   #        pass_filenames: false
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: ""
+    rev: "v18.1.1"
     hooks:
       - id: clang-format
         entry: clang-format -i
@@ -51,7 +51,7 @@ repos:
 
   # black ~ Formats Python code
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.3.0
     hooks:
       - id: black
         args: ["--line-length=120"]
@@ -65,7 +65,7 @@ repos:
 
   # hadolint ~ Docker linter
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.0
+    rev: v2.12.1-beta
     hooks:
       - id: hadolint-docker
         args: [
@@ -74,6 +74,6 @@ repos:
 
   # ShellCheck ~ Gives warnings and suggestions for bash/sh shell scripts
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.9.0
+    rev: v0.10.0
     hooks:
       - id: shellcheck

--- a/api/test/test_covjson.py
+++ b/api/test/test_covjson.py
@@ -22,15 +22,17 @@ def test_single_parameter_convert():
 
     # Assert that the coverage collection has the correct parameter
     # TODO: Change parameter name when parameter names have been decided
-    assert "ff" in coverage_collection.parameters.keys()
+    assert "wind_speed:10:mean:PT10M" in coverage_collection.parameters.keys()
 
     # Check that correct values exist in the coverage collection
-    assert 9.21 in coverage_collection.ranges["ff"].values
+    assert 9.21 in coverage_collection.ranges["wind_speed:10:mean:PT10M"].values
 
     assert len(coverage_collection.domain.axes.t.values) == 7
 
     # Number of time points should match with the number of observation values
-    assert len(coverage_collection.domain.axes.t.values) == len(coverage_collection.ranges["ff"].values)
+    assert len(coverage_collection.domain.axes.t.values) == len(
+        coverage_collection.ranges["wind_speed:10:mean:PT10M"].values
+    )
 
     # compare the coverage collection with the compare data
     # TODO: Modify compare data when parameter names have been decided
@@ -52,12 +54,15 @@ def test_multiple_parameter_convert():
 
     # Check that the coverage collection has the correct parameters
     # TODO: Change parameter names when parameter names have been decided
-    assert set(["dd", "ff", "rh"]) == coverage_collection.parameters.keys()
+    assert (
+        set(["wind_from_direction:2.0:mean:PT10M", "wind_speed:10:mean:PT10M", "relative_humidity:2.0:mean:PT1M"])
+        == coverage_collection.parameters.keys()
+    )
 
     # Check that correct values exist in the coverage collection
-    assert 230.7 in coverage_collection.ranges["dd"].values
-    assert 9.19 in coverage_collection.ranges["ff"].values
-    assert 88.0 in coverage_collection.ranges["rh"].values
+    assert 230.7 in coverage_collection.ranges["wind_from_direction:2.0:mean:PT10M"].values
+    assert 9.19 in coverage_collection.ranges["wind_speed:10:mean:PT10M"].values
+    assert 88.0 in coverage_collection.ranges["relative_humidity:2.0:mean:PT1M"].values
 
     # TODO: Modify compare data when parameter names have been decided
     coverage_collection_json = json.loads(coverage_collection.model_dump_json(exclude_none=True))
@@ -82,7 +87,9 @@ def test_single_parameter_area_convert():
 
     # Check that each coverage has the correct parameter
     # TODO: Change parameter name when parameter names have been decided
-    assert all(["TA_P1D_AVG" in coverage.parameters.keys() for coverage in coverage_collection.coverages])
+    assert all(
+        ["air_temperature:2.0:average:PT1D" in coverage.parameters.keys() for coverage in coverage_collection.coverages]
+    )
 
     # TODO: Modify compare data when parameter names have been decided
     coverage_collection_json = json.loads(coverage_collection.model_dump_json(exclude_none=True))

--- a/api/test/test_data/test_coverages_covjson.json
+++ b/api/test/test_data/test_coverages_covjson.json
@@ -46,9 +46,13 @@
                 ]
             },
             "parameters": {
-                "TA_P1D_AVG": {
+                "air_temperature:2.0:average:PT1D": {
                     "type": "Parameter",
+                    "description": {
+                        "en": "Air Temperature 1d average"
+                    },
                     "observedProperty": {
+                        "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature",
                         "label": {
                             "en": "TA_P1D_AVG"
                         }
@@ -61,7 +65,7 @@
                 }
             },
             "ranges": {
-                "TA_P1D_AVG": {
+                "air_temperature:2.0:average:PT1D": {
                     "type": "NdArray",
                     "dataType": "float",
                     "axisNames": [
@@ -125,9 +129,13 @@
                 ]
             },
             "parameters": {
-                "TA_P1D_AVG": {
+                "air_temperature:2.0:average:PT1D": {
                     "type": "Parameter",
+                    "description": {
+                        "en": "Air Temperature 1d average"
+                    },
                     "observedProperty": {
+                        "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature",
                         "label": {
                             "en": "TA_P1D_AVG"
                         }
@@ -140,7 +148,7 @@
                 }
             },
             "ranges": {
-                "TA_P1D_AVG": {
+                "air_temperature:2.0:average:PT1D": {
                     "type": "NdArray",
                     "dataType": "float",
                     "axisNames": [
@@ -161,9 +169,13 @@
         }
     ],
     "parameters": {
-        "TA_P1D_AVG": {
+        "air_temperature:2.0:average:PT1D": {
             "type": "Parameter",
+            "description": {
+                "en": "Air Temperature 1d average"
+            },
             "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature",
                 "label": {
                     "en": "TA_P1D_AVG"
                 }

--- a/api/test/test_data/test_coverages_proto.json
+++ b/api/test/test_data/test_coverages_proto.json
@@ -2,11 +2,15 @@
     "observations": [
         {
             "ts_mdata": {
-                "title": "FMI test data",
-                "platform": "100945",
-                "standard_name": "TA_P1D_AVG",
+                "title": "Air Temperature 1d average",
+                "platform": "0-246-0-100945",
+                "standard_name": "air_temperature",
                 "unit": "degC",
-                "instrument": "TA_P1D_AVG"
+                "instrument": "TA_P1D_AVG",
+                "level": "2.0",
+                "period": "P1D",
+                "function": "average",
+                "parameter_name": "air_temperature:2.0:average:PT1D"
             },
             "obs_mdata": [
                 {
@@ -15,7 +19,6 @@
                         "lat": 59.86948983,
                         "lon": 22.19342704
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:00:00Z",
                     "value": "5.2"
                 }
@@ -23,11 +26,15 @@
         },
         {
             "ts_mdata": {
-                "title": "FMI test data",
-                "platform": "100976",
-                "standard_name": "TA_P1D_AVG",
+                "title": "Air Temperature 1d average",
+                "platform": "0-246-0-100976",
+                "standard_name": "air_temperature",
                 "unit": "degC",
-                "instrument": "TA_P1D_AVG"
+                "instrument": "TA_P1D_AVG",
+                "level": "2.0",
+                "period": "P1D",
+                "function": "average",
+                "parameter_name": "air_temperature:2.0:average:PT1D"
             },
             "obs_mdata": [
                 {
@@ -36,7 +43,6 @@
                         "lat": 60.41875496,
                         "lon": 24.3986218
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:00:00Z",
                     "value": "3.7"
                 }

--- a/api/test/test_data/test_multiple_covjson.json
+++ b/api/test/test_data/test_multiple_covjson.json
@@ -45,9 +45,30 @@
         ]
     },
     "parameters": {
-        "dd": {
+        "relative_humidity:2.0:mean:PT1M": {
             "type": "Parameter",
+            "description": {
+                "en": "Relative Humidity 1 Min Average"
+            },
             "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/relative_humidity",
+                "label": {
+                    "en": "rh"
+                }
+            },
+            "unit": {
+                "label": {
+                    "en": "%"
+                }
+            }
+        },
+        "wind_from_direction:2.0:mean:PT10M": {
+            "type": "Parameter",
+            "description": {
+                "en": "Wind Direction 10 Min Average"
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/wind_from_direction",
                 "label": {
                     "en": "dd"
                 }
@@ -58,9 +79,13 @@
                 }
             }
         },
-        "ff": {
+        "wind_speed:10:mean:PT10M": {
             "type": "Parameter",
+            "description": {
+                "en": "Wind Speed at 10m 10 Min Average"
+            },
             "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/wind_speed",
                 "label": {
                     "en": "ff"
                 }
@@ -70,23 +95,29 @@
                     "en": "m s-1"
                 }
             }
-        },
-        "rh": {
-            "type": "Parameter",
-            "observedProperty": {
-                "label": {
-                    "en": "rh"
-                }
-            },
-            "unit": {
-                "label": {
-                    "en": "%"
-                }
-            }
         }
     },
     "ranges": {
-        "dd": {
+        "relative_humidity:2.0:mean:PT1M": {
+            "type": "NdArray",
+            "dataType": "float",
+            "axisNames": [
+                "t",
+                "y",
+                "x"
+            ],
+            "shape": [
+                3,
+                1,
+                1
+            ],
+            "values": [
+                88,
+                88,
+                88
+            ]
+        },
+        "wind_from_direction:2.0:mean:PT10M": {
             "type": "NdArray",
             "dataType": "float",
             "axisNames": [
@@ -105,7 +136,7 @@
                 232.9
             ]
         },
-        "ff": {
+        "wind_speed:10:mean:PT10M": {
             "type": "NdArray",
             "dataType": "float",
             "axisNames": [
@@ -122,25 +153,6 @@
                 9.71,
                 9.32,
                 9.19
-            ]
-        },
-        "rh": {
-            "type": "NdArray",
-            "dataType": "float",
-            "axisNames": [
-                "t",
-                "y",
-                "x"
-            ],
-            "shape": [
-                3,
-                1,
-                1
-            ],
-            "values": [
-                88,
-                88,
-                88
             ]
         }
     }

--- a/api/test/test_data/test_multiple_proto.json
+++ b/api/test/test_data/test_multiple_proto.json
@@ -3,10 +3,14 @@
         {
             "ts_mdata": {
                 "title": "Wind Speed at 10m 10 Min Average",
-                "platform": "06280",
+                "platform": "0-20000-0-06280",
                 "standard_name": "wind_speed",
                 "unit": "m s-1",
-                "instrument": "ff"
+                "instrument": "ff",
+                "level": "10",
+                "period": "PT10M",
+                "function": "mean",
+                "parameter_name": "wind_speed:10:mean:PT10M"
             },
             "obs_mdata": [
                 {
@@ -15,7 +19,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:00:00Z",
                     "value": "9.71"
                 },
@@ -25,7 +28,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:10:00Z",
                     "value": "9.32"
                 },
@@ -35,7 +37,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:20:00Z",
                     "value": "9.19"
                 }
@@ -44,10 +45,14 @@
         {
             "ts_mdata": {
                 "title": "Wind Direction 10 Min Average",
-                "platform": "06280",
+                "platform": "0-20000-0-06280",
                 "standard_name": "wind_from_direction",
                 "unit": "degree",
-                "instrument": "dd"
+                "instrument": "dd",
+                "level": "2.0",
+                "period": "PT10M",
+                "function": "mean",
+                "parameter_name": "wind_from_direction:2.0:mean:PT10M"
             },
             "obs_mdata": [
                 {
@@ -56,7 +61,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:00:00Z",
                     "value": "226.7"
                 },
@@ -66,7 +70,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:10:00Z",
                     "value": "230.7"
                 },
@@ -76,7 +79,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:20:00Z",
                     "value": "232.9"
                 }
@@ -85,10 +87,14 @@
         {
             "ts_mdata": {
                 "title": "Relative Humidity 1 Min Average",
-                "platform": "06280",
+                "platform": "0-20000-0-06280",
                 "standard_name": "relative_humidity",
                 "unit": "%",
-                "instrument": "rh"
+                "instrument": "rh",
+                "level": "2.0",
+                "period": "PT10M",
+                "function": "mean",
+                "parameter_name": "relative_humidity:2.0:mean:PT1M"
             },
             "obs_mdata": [
                 {
@@ -97,7 +103,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:00:00Z",
                     "value": "88.0"
                 },
@@ -107,7 +112,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:10:00Z",
                     "value": "88.0"
                 },
@@ -117,7 +121,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:20:00Z",
                     "value": "88.0"
                 }

--- a/api/test/test_data/test_single_covjson.json
+++ b/api/test/test_data/test_single_covjson.json
@@ -49,9 +49,13 @@
         ]
     },
     "parameters": {
-        "ff": {
+        "wind_speed:10:mean:PT10M": {
             "type": "Parameter",
+            "description": {
+                "en": "Wind Speed at 10m 10 Min Average"
+            },
             "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/wind_speed",
                 "label": {
                     "en": "ff"
                 }
@@ -64,7 +68,7 @@
         }
     },
     "ranges": {
-        "ff": {
+        "wind_speed:10:mean:PT10M": {
             "type": "NdArray",
             "dataType": "float",
             "axisNames": [

--- a/api/test/test_data/test_single_proto.json
+++ b/api/test/test_data/test_single_proto.json
@@ -3,10 +3,14 @@
         {
             "ts_mdata": {
                 "title": "Wind Speed at 10m 10 Min Average",
-                "platform": "06280",
+                "platform": "0-20000-0-06280",
                 "standard_name": "wind_speed",
                 "unit": "m s-1",
-                "instrument": "ff"
+                "instrument": "ff",
+                "level": "10",
+                "period": "PT10M",
+                "function": "mean",
+                "parameter_name": "wind_speed:10:mean:PT10M"
             },
             "obs_mdata": [
                 {
@@ -15,7 +19,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:00:00Z",
                     "value": "9.71"
                 },
@@ -25,7 +28,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:10:00Z",
                     "value": "9.32"
                 },
@@ -35,7 +37,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:20:00Z",
                     "value": "9.19"
                 },
@@ -45,7 +46,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:30:00Z",
                     "value": "9.21"
                 },
@@ -55,7 +55,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:40:00Z",
                     "value": "8.7"
                 },
@@ -65,7 +64,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T00:50:00Z",
                     "value": "8.12"
                 },
@@ -75,7 +73,6 @@
                         "lat": 53.123676213651,
                         "lon": 6.5848470019087
                     },
-                    "pubtime": "1970-01-01T00:00:00Z",
                     "obstime_instant": "2022-12-31T01:00:00Z",
                     "value": "7.28"
                 }

--- a/api/test/test_edr.py
+++ b/api/test/test_edr.py
@@ -191,6 +191,5 @@ def test_get_position_with_incorrect_geometry_type():
         "24.39 60.41, 24.39 59.86, 22.12 59.86))"
     )
 
-    assert False
     assert response.status_code == 400
     assert response.json() == {"detail": {"coords": "Invalid geometric type: Polygon"}}

--- a/api/test/test_edr.py
+++ b/api/test/test_edr.py
@@ -191,5 +191,6 @@ def test_get_position_with_incorrect_geometry_type():
         "24.39 60.41, 24.39 59.86, 22.12 59.86))"
     )
 
+    assert False
     assert response.status_code == 400
     assert response.json() == {"detail": {"coords": "Invalid geometric type: Polygon"}}


### PR DESCRIPTION
Closes #73

- Build filter & datetime when needed for obs request
- Update API unit tests and notify when tests fail
- Update pre-commit hooks config

Note /locations request filtering is fixed in #66 