### PR TITLE
Improved error reporting from gRPC method calls

### DIFF
--- a/datastore/datastore/dsimpl/getextents.go
+++ b/datastore/datastore/dsimpl/getextents.go
@@ -5,15 +5,19 @@ import (
 	"fmt"
 
 	"datastore/datastore"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (svcInfo *ServiceInfo) GetExtents(
 	ctx context.Context, request *datastore.GetExtentsRequest) (
 	*datastore.GetExtentsResponse, error) {
 
-	response, err := svcInfo.Sbe.GetExtents(request)
-	if err != nil {
-		return nil, fmt.Errorf("svcInfo.Sbe.GetExtents() failed: %v", err)
+	response, errCode, reason := svcInfo.Sbe.GetExtents(request)
+	if errCode != codes.OK {
+		return nil, status.Error(
+			errCode, fmt.Sprintf("svcInfo.Sbe.GetExtents() failed: %s", reason))
 	}
 
 	return response, nil

--- a/datastore/datastore/dsimpl/getobservations.go
+++ b/datastore/datastore/dsimpl/getobservations.go
@@ -6,6 +6,9 @@ import (
 
 	"datastore/common"
 	"datastore/datastore"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // getTemporalSpec derives and validates a temporal specification from request.
@@ -36,12 +39,14 @@ func (svcInfo *ServiceInfo) GetObservations(
 
 	tspec, err := getTemporalSpec(request)
 	if err != nil {
-		return nil, fmt.Errorf("dsimpl.GetTemporalSpec() failed: %v", err)
+		return nil, status.Error(
+			codes.Internal, fmt.Sprintf("getTemporalSpec() failed: %v", err))
 	}
 
-	response, err := svcInfo.Sbe.GetObservations(request, tspec)
-	if err != nil {
-		return nil, fmt.Errorf("svcInfo.Sbe.GetObservations() failed: %v", err)
+	response, errCode, reason := svcInfo.Sbe.GetObservations(request, tspec)
+	if errCode != codes.OK {
+		return nil, status.Error(
+			errCode, fmt.Sprintf("svcInfo.Sbe.GetObservations() failed: %s", reason))
 	}
 
 	return response, nil

--- a/datastore/datastore/dsimpl/gettsattrgroups.go
+++ b/datastore/datastore/dsimpl/gettsattrgroups.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"datastore/datastore"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (svcInfo *ServiceInfo) GetTSAttrGroups(
@@ -12,12 +15,13 @@ func (svcInfo *ServiceInfo) GetTSAttrGroups(
 
 	// ensure that at least one attribute is specified
 	if len(request.Attrs) == 0 {
-		return nil, fmt.Errorf("no attributes specified")
+		return nil, status.Error(codes.InvalidArgument, "no attributes specified")
 	}
 
-	response, err := svcInfo.Sbe.GetTSAttrGroups(request)
-	if err != nil {
-		return nil, fmt.Errorf("svcInfo.Sbe.GetTSAttrGroups() failed: %v", err)
+	response, errCode, reason := svcInfo.Sbe.GetTSAttrGroups(request)
+	if errCode != codes.OK {
+		return nil, status.Error(
+			errCode, fmt.Sprintf("svcInfo.Sbe.GetTSAttrGroups() failed: %s", reason))
 	}
 
 	return response, nil

--- a/datastore/datastore/dsimpl/putobservations.go
+++ b/datastore/datastore/dsimpl/putobservations.go
@@ -5,15 +5,19 @@ import (
 	"fmt"
 
 	"datastore/datastore"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (svcInfo *ServiceInfo) PutObservations(
 	ctx context.Context, request *datastore.PutObsRequest) (
 	*datastore.PutObsResponse, error) {
 
-	err := svcInfo.Sbe.PutObservations(request)
-	if err != nil {
-		return nil, fmt.Errorf("svcInfo.Sbe.PutObservations() failed: %v", err)
+	errCode, reason := svcInfo.Sbe.PutObservations(request)
+	if errCode != codes.OK {
+		return nil, status.Error(
+			errCode, fmt.Sprintf("svcInfo.Sbe.PutObservations() failed: %s", reason))
 	}
 
 	return &datastore.PutObsResponse{

--- a/datastore/datastore/main/main.go
+++ b/datastore/datastore/main/main.go
@@ -34,7 +34,10 @@ func createStorageBackend() (storagebackend.StorageBackend, error) {
 }
 
 func main() {
-	reqTimeLogger := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+
+	reqTimeLogger := func(
+		ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler) (interface{}, error) {
 		start := time.Now()
 		resp, err := handler(ctx, req)
 		reqTime := time.Since(start)
@@ -70,7 +73,7 @@ func main() {
 	// serve profiling info
 	log.Printf("serving profiling info\n")
 	go func() {
-		http.ListenAndServe(fmt.Sprintf("0.0.0.0:6060"), nil)
+		http.ListenAndServe("0.0.0.0:6060", nil)
 	}()
 
 	// serve incoming requests

--- a/datastore/datastore/storagebackend/postgresql/getextents.go
+++ b/datastore/datastore/storagebackend/postgresql/getextents.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -53,22 +54,22 @@ func getSpatialExtent(db *sql.DB) (*datastore.BoundingBox, error) {
 
 // GetExtents ... (see documentation in StorageBackend interface)
 func (sbe *PostgreSQL) GetExtents(request *datastore.GetExtentsRequest) (
-	*datastore.GetExtentsResponse, error) {
+	*datastore.GetExtentsResponse, codes.Code, string) {
 
 	var err error
 
 	temporalExtent, err := getTemporalExtent(sbe.Db)
 	if err != nil {
-		return nil, fmt.Errorf("getTemporalExtent() failed: %v", err)
+		return nil, codes.Internal, fmt.Sprintf("getTemporalExtent() failed: %v", err)
 	}
 
 	spatialExtent, err := getSpatialExtent(sbe.Db)
 	if err != nil {
-		return nil, fmt.Errorf("getSpatialExtent() failed: %v", err)
+		return nil, codes.Internal, fmt.Sprintf("getSpatialExtent() failed: %v", err)
 	}
 
 	return &datastore.GetExtentsResponse{
 		TemporalExtent: temporalExtent,
 		SpatialExtent:  spatialExtent,
-	}, nil
+	}, codes.OK, ""
 }

--- a/datastore/datastore/storagebackend/postgresql/getobservations.go
+++ b/datastore/datastore/storagebackend/postgresql/getobservations.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cridenour/go-postgis"
 	"github.com/lib/pq"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -625,20 +626,20 @@ func getObs(
 // GetObservations ... (see documentation in StorageBackend interface)
 func (sbe *PostgreSQL) GetObservations(
 	request *datastore.GetObsRequest, tspec common.TemporalSpec) (
-	*datastore.GetObsResponse, error) {
+	*datastore.GetObsResponse, codes.Code, string) {
 
 	var err error
 
 	incFields, err := getIncRespFields(request)
 	if err != nil {
-		return nil, fmt.Errorf("getIncRespFields() failed: %v", err)
+		return nil, codes.Internal, fmt.Sprintf("getIncRespFields() failed: %v", err)
 	}
 
 	obs := []*datastore.Metadata2{}
 	if err = getObs(
 		sbe.Db, request, tspec, &obs, incFields); err != nil {
-		return nil, fmt.Errorf("getObs() failed: %v", err)
+		return nil, codes.Internal, fmt.Sprintf("getObs() failed: %v", err)
 	}
 
-	return &datastore.GetObsResponse{Observations: obs}, nil
+	return &datastore.GetObsResponse{Observations: obs}, codes.OK, ""
 }

--- a/datastore/datastore/storagebackend/postgresql/gettsattrgroups.go
+++ b/datastore/datastore/storagebackend/postgresql/gettsattrgroups.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	_ "github.com/lib/pq"
+	"google.golang.org/grpc/codes"
 )
 
 // getTSGoNamesFromPBNames returns Go names names corresponding to pbNames.
@@ -293,10 +294,10 @@ func getTSAttrGroupsComboOnly(db *sql.DB, cols []string) ([]*datastore.TSMdataGr
 
 // GetTSAttrGroups ... (see documentation in StorageBackend interface)
 func (sbe *PostgreSQL) GetTSAttrGroups(request *datastore.GetTSAGRequest) (
-	*datastore.GetTSAGResponse, error) {
+	*datastore.GetTSAGResponse, codes.Code, string) {
 
 	if err := validateAttrs(request.Attrs); err != nil {
-		return nil, fmt.Errorf("validateAttrs() failed: %v", err)
+		return nil, codes.Internal, fmt.Sprintf("validateAttrs() failed: %v", err)
 	}
 
 	var groups []*datastore.TSMdataGroup
@@ -304,13 +305,14 @@ func (sbe *PostgreSQL) GetTSAttrGroups(request *datastore.GetTSAGRequest) (
 
 	if request.IncludeInstances {
 		if groups, err = getTSAttrGroupsIncInstances(sbe.Db, request.Attrs); err != nil {
-			return nil, fmt.Errorf("getTSAttrGroupsIncInstances() failed: %v", err)
+			return nil, codes.Internal,
+				fmt.Sprintf("getTSAttrGroupsIncInstances() failed: %v", err)
 		}
 	} else {
 		if groups, err = getTSAttrGroupsComboOnly(sbe.Db, request.Attrs); err != nil {
-			return nil, fmt.Errorf("getTSAttrGroupsComboOnly() failed: %v", err)
+			return nil, codes.Internal, fmt.Sprintf("getTSAttrGroupsComboOnly() failed: %v", err)
 		}
 	}
 
-	return &datastore.GetTSAGResponse{Groups: groups}, nil
+	return &datastore.GetTSAGResponse{Groups: groups}, codes.OK, ""
 }

--- a/datastore/datastore/storagebackend/storagebackend.go
+++ b/datastore/datastore/storagebackend/storagebackend.go
@@ -2,7 +2,9 @@ package storagebackend
 
 import (
 	"datastore/common"
-	"datastore/datastore"
+	datastore "datastore/datastore"
+
+	"google.golang.org/grpc/codes"
 )
 
 // StorageBackend is the interface for an observation storage backend.
@@ -12,19 +14,24 @@ type StorageBackend interface {
 	Description() string
 
 	// PutObservations inserts observations in the storage.
-	// Returns nil upon success, otherwise error.
-	PutObservations(*datastore.PutObsRequest) error
+	//
+	// Returns (codes.OK, ...) upon success, otherwise (error code, reason).
+	PutObservations(*datastore.PutObsRequest) (codes.Code, string)
 
 	// GetObservations retrieves observations from the storage.
-	// Returns nil upon success, otherwise error.
+	//
+	// Returns (observations, codes.OK, ...) upon success, otherwise (..., error code, reason).
 	GetObservations(*datastore.GetObsRequest, common.TemporalSpec) (
-		*datastore.GetObsResponse, error)
+		*datastore.GetObsResponse, codes.Code, string)
 
 	// GetTSAttrGroups retrieves, for the non-default attributes in the input, the unique
 	// combinations of attribute values currently represented in the storage.
-	GetTSAttrGroups(*datastore.GetTSAGRequest) (*datastore.GetTSAGResponse, error)
+	//
+	// Returns (combos, codes.OK, ...) upon success, otherwise (..., error code, reason).
+	GetTSAttrGroups(*datastore.GetTSAGRequest) (*datastore.GetTSAGResponse, codes.Code, string)
 
 	// GetExtents gets the time- and geo extents of all currently stored observations.
-	// Returns nil upon success, otherwise error.
-	GetExtents(*datastore.GetExtentsRequest) (*datastore.GetExtentsResponse, error)
+	//
+	// Returns (extents, codes.OK, ...) upon success, otherwise (..., error code, reason).
+	GetExtents(*datastore.GetExtentsRequest) (*datastore.GetExtentsResponse, codes.Code, string)
 }


### PR DESCRIPTION
This change improves error report from gRPC method calls by setting the status field to one of the codes defined in the [codes](https://pkg.go.dev/google.golang.org/grpc/codes) package.

**NOTE:** Many (most?) of the occurrences of `codes.Internal` can be set to something more precise if we let the code propagate up the call stack all the way from where the error originates.