### PR TITLE
Make parameter wildcards work again.

### DIFF
--- a/api/routers/edr.py
+++ b/api/routers/edr.py
@@ -60,6 +60,10 @@ async def get_locations(
         str | None,
         Query(
             alias="parameter-name",
+            description="Comma seperated list of parameter names. Each consists of four components seperated by colons."
+            " The components are standard name, level in meters, aggregation function, and period. "
+            "Each of the components can be replaced by the wildcard character `*`. "
+            "To get all the air temperatures measured at 1.5 meter, use `air_temperature:1.5:*:*`.",
             example="wind_from_direction:2.0:mean:PT10M,"
             "wind_speed:10:mean:PT10M,"
             "relative_humidity:2.0:mean:PT1M,"
@@ -178,6 +182,10 @@ async def get_data_location_id(
         str | None,
         Query(
             alias="parameter-name",
+            description="Comma seperated list of parameter names. Each consists of four components seperated by colons."
+            " The components are standard name, level in meters, aggregation function, and period. "
+            "Each of the components can be replaced by the wildcard character `*`. "
+            "To get all the air temperatures measured at 1.5 meter, use `air_temperature:1.5:*:*`.",
             example="wind_from_direction:2.0:mean:PT10M,"
             "wind_speed:10:mean:PT10M,"
             "relative_humidity:2.0:mean:PT1M,"
@@ -214,6 +222,10 @@ async def get_data_position(
         str | None,
         Query(
             alias="parameter-name",
+            description="Comma seperated list of parameter names. Each consists of four components seperated by colons."
+            " The components are standard name, level in meters, aggregation function, and period. "
+            "Each of the components can be replaced by the wildcard character `*`. "
+            "To get all the air temperatures measured at 1.5 meter, use `air_temperature:1.5:*:*`.",
             example="wind_from_direction:2.0:mean:PT10M,"
             "wind_speed:10:mean:PT10M,"
             "relative_humidity:2.0:mean:PT1M,"
@@ -270,6 +282,10 @@ async def get_data_area(
         str | None,
         Query(
             alias="parameter-name",
+            description="Comma seperated list of parameter names. Each consists of four components seperated by colons."
+            " The components are standard name, level in meters, aggregation function, and period. "
+            "Each of the components can be replaced by the wildcard character `*`. "
+            "To get all the air temperatures measured at 1.5 meter, use `air_temperature:1.5:*:*`.",
             example="wind_from_direction:2.0:mean:PT10M,"
             "wind_speed:10:mean:PT10M,"
             "relative_humidity:2.0:mean:PT1M,"

--- a/api/utilities.py
+++ b/api/utilities.py
@@ -71,9 +71,13 @@ async def verify_parameter_names(parameter_names: list) -> None:
     Raises error with unknown names if any are found.
     """
     unknown_parameter_names = []
+    current_parameter_names = await get_current_parameter_names()
 
     for i in parameter_names:
-        if i not in await get_current_parameter_names():
+        # HACK: This checking breaks the wildcard support (e.g. air_temperature:*:*:*). Skip if contains wildcards
+        if "*" in i:
+            continue
+        if i not in current_parameter_names:
             unknown_parameter_names.append(i)
 
     if unknown_parameter_names:

--- a/datastore/integration-test/response/data_area_two_locations_with_paraneter_with_wildcard.json
+++ b/datastore/integration-test/response/data_area_two_locations_with_paraneter_with_wildcard.json
@@ -1,0 +1,117 @@
+{
+    "type": "Coverage",
+    "domain": {
+        "type": "Domain",
+        "domainType": "PointSeries",
+        "axes": {
+            "x": {
+                "values": [
+                    4.6029300588208
+                ]
+            },
+            "y": {
+                "values": [
+                    52.505333893732
+                ]
+            },
+            "t": {
+                "values": [
+                    "2022-12-31T00:00:00Z"
+                ]
+            }
+        },
+        "referencing": [
+            {
+                "coordinates": [
+                    "y",
+                    "x"
+                ],
+                "system": {
+                    "type": "GeographicCRS",
+                    "id": "http://www.opengis.net/def/crs/EPSG/0/4326"
+                }
+            },
+            {
+                "coordinates": [
+                    "t"
+                ],
+                "system": {
+                    "type": "TemporalRS",
+                    "calendar": "Gregorian"
+                }
+            }
+        ]
+    },
+    "parameters": {
+        "air_temperature:2.0:maximum:PT6H": {
+            "type": "Parameter",
+            "description": {
+                "en": "air_temperature at 2.0m PT6H maximum"
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature",
+                "label": {
+                    "en": "air_temperature:2.0:maximum:PT6H"
+                }
+            },
+            "unit": {
+                "label": {
+                    "en": "degrees Celsius"
+                }
+            }
+        },
+        "air_temperature:2.0:minimum:PT6H": {
+            "type": "Parameter",
+            "description": {
+                "en": "air_temperature at 2.0m PT6H minimum"
+            },
+            "observedProperty": {
+                "id": "https://vocab.nerc.ac.uk/standard_name/air_temperature",
+                "label": {
+                    "en": "air_temperature:2.0:minimum:PT6H"
+                }
+            },
+            "unit": {
+                "label": {
+                    "en": "degrees Celsius"
+                }
+            }
+        }
+    },
+    "ranges": {
+        "air_temperature:2.0:maximum:PT6H": {
+            "type": "NdArray",
+            "dataType": "float",
+            "axisNames": [
+                "t",
+                "y",
+                "x"
+            ],
+            "shape": [
+                1,
+                1,
+                1
+            ],
+            "values": [
+                10.8
+            ]
+        },
+        "air_temperature:2.0:minimum:PT6H": {
+            "type": "NdArray",
+            "dataType": "float",
+            "axisNames": [
+                "t",
+                "y",
+                "x"
+            ],
+            "shape": [
+                1,
+                1,
+                1
+            ],
+            "values": [
+                9.9
+            ]
+        }
+    }
+}

--- a/datastore/integration-test/test_api.py
+++ b/datastore/integration-test/test_api.py
@@ -203,6 +203,23 @@ def test_from_a_single_collection_get_an_area_with_two_parameters():
     actual_response_is_expected_response(actual_response, expected_json)
 
 
+def test_from_a_single_collection_get_an_area_with_parameter_with_wildcard():
+    collection_id = "observations"
+    coords = "POLYGON((4.0 52.4, 4.7 52.4,4.7 52.6,4.0 52.6, 4.0 52.4))"
+    parameters = "air_temperature:2.0:*:PT6H"
+    datetime = "2022-12-31T00:00:00Z"
+    actual_response = requests.get(
+        url=BASE_URL + f"/collections/{collection_id}/area"
+        f"?coords={coords}&parameter-name={parameters}&datetime={datetime}"
+    )
+
+    expected_json = load_json("response/data_area_two_locations_with_paraneter_with_wildcard.json")
+
+    assert actual_response.status_code == 200
+    assert actual_response.headers["Content-Type"] == "application/prs.coverage+json"
+    actual_response_is_expected_response(actual_response, expected_json)
+
+
 def test_items_get_area():
     collection_id = "observations"
     bbox = "4.5,52.4,4.6,52.57"


### PR DESCRIPTION
Also added integration test for this. And call `get_current_parameter_names()` once instead of for each requested parameter.