### PR TITLE
Set up max connections for SQL connection pool.

### DIFF
--- a/datastore/datastore/go.mod
+++ b/datastore/datastore/go.mod
@@ -2,18 +2,18 @@ module datastore
 
 go 1.20
 
-require google.golang.org/grpc v1.56.1
+require google.golang.org/grpc v1.64.0
 
 require (
 	github.com/cridenour/go-postgis v1.0.0
-	google.golang.org/protobuf v1.31.0
+	google.golang.org/protobuf v1.34.1
 )
 
 require (
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/lib/pq v1.10.0
-	golang.org/x/net v0.11.0 // indirect
-	golang.org/x/sys v0.9.0 // indirect
-	golang.org/x/text v0.10.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230629202037-9506855d4529 // indirect
+	github.com/lib/pq v1.10.9
+	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/text v0.16.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117 // indirect
 )

--- a/datastore/datastore/storagebackend/postgresql/postgresql.go
+++ b/datastore/datastore/storagebackend/postgresql/postgresql.go
@@ -130,6 +130,7 @@ func openDB(host, port, user, password, dbname string) (*sql.DB, error) {
 	db.SetMaxOpenConns(25)
 	db.SetMaxIdleConns(25)
 	db.SetConnMaxLifetime(5 * time.Minute)
+	db.SetConnMaxIdleTime(5 * time.Minute)
 
 	return db, nil
 }

--- a/datastore/datastore/storagebackend/postgresql/postgresql.go
+++ b/datastore/datastore/storagebackend/postgresql/postgresql.go
@@ -126,6 +126,11 @@ func openDB(host, port, user, password, dbname string) (*sql.DB, error) {
 		return nil, fmt.Errorf("sql.Open() failed: %v", err)
 	}
 
+	// Set up connection pooling
+	db.SetMaxOpenConns(25)
+	db.SetMaxIdleConns(25)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
 	return db, nil
 }
 

--- a/datastore/load-test/locustfile_read.py
+++ b/datastore/load-test/locustfile_read.py
@@ -73,5 +73,5 @@ class StoreGrpcUser(grpc_user.GrpcUser):
             ),
         )
         response = self.stub.GetObservations(request)
-        assert len(response.observations) == 0
+        assert len(response.observations) == 1
         assert len(response.observations[0].obs_mdata) == 144

--- a/datastore/load-test/locustfile_read.py
+++ b/datastore/load-test/locustfile_read.py
@@ -73,5 +73,5 @@ class StoreGrpcUser(grpc_user.GrpcUser):
             ),
         )
         response = self.stub.GetObservations(request)
-        assert len(response.observations) == 1
+        assert len(response.observations) == 0
         assert len(response.observations[0].obs_mdata) == 144


### PR DESCRIPTION
Double check this doesn't break anything by looking if the load test still works correctly.

Are we properly "closing" all connections, meaning giving them back to the pool, after usage?
Because it surprises me we are actually using all 100 allowed connections with the current setup, are we leaking them?