### PR TITLE
Disable check for inconsistent parameters

### DIFF
--- a/api/metadata_endpoints.py
+++ b/api/metadata_endpoints.py
@@ -20,7 +20,6 @@ from edr_pydantic.observed_property import ObservedProperty
 from edr_pydantic.parameter import Parameter
 from edr_pydantic.unit import Unit
 from edr_pydantic.variables import Variables
-from fastapi import HTTPException
 from grpc_getter import get_extents_request
 from grpc_getter import get_ts_ag_request
 

--- a/api/metadata_endpoints.py
+++ b/api/metadata_endpoints.py
@@ -88,14 +88,17 @@ async def get_collection_metadata(base_url: str, is_self) -> Collection:
             ),
             unit=Unit(label=ts.unit),
         )
-        if ts.parameter_name in all_parameters:
-            raise HTTPException(
-                status_code=500,
-                detail={
-                    "parameter": f"Parameter with name {ts.parameter_name} "
-                    f"has multiple definitions:\n{all_parameters[ts.parameter_name]}\n{parameter}"
-                },
-            )
+        # Check for inconsistent parameter definitions between stations
+        # HACK: Avoid this error for now. We always return the last value found in /locations and collection metedata.
+        # Note that the correct UoM is always returned for a time series in the Coverage parameters.
+        # if ts.parameter_name in all_parameters:
+        #     raise HTTPException(
+        #         status_code=500,
+        #         detail={
+        #             "parameter": f"Parameter with name {ts.parameter_name} "
+        #             f"has multiple definitions:\n{all_parameters[ts.parameter_name]}\n{parameter}"
+        #         },
+        #     )
 
         all_parameters[ts.parameter_name] = parameter
 

--- a/api/metadata_endpoints.py
+++ b/api/metadata_endpoints.py
@@ -88,17 +88,9 @@ async def get_collection_metadata(base_url: str, is_self) -> Collection:
             ),
             unit=Unit(label=ts.unit),
         )
-        # Check for inconsistent parameter definitions between stations
-        # HACK: Avoid this error for now. We always return the last value found in /locations and collection metedata.
-        # Note that the correct UoM is always returned for a time series in the Coverage parameters.
-        # if ts.parameter_name in all_parameters:
-        #     raise HTTPException(
-        #         status_code=500,
-        #         detail={
-        #             "parameter": f"Parameter with name {ts.parameter_name} "
-        #             f"has multiple definitions:\n{all_parameters[ts.parameter_name]}\n{parameter}"
-        #         },
-        #     )
+        # There might be parameter inconsistencies (e.g one station is reporting in Pa, and another in hPa)
+        # We always return the "last" parameter definition found (in /locations and collection metadata).
+        # Note that the correct UoM is always returned in the Coverage parameters for the data endpoints.
 
         all_parameters[ts.parameter_name] = parameter
 

--- a/api/routers/edr.py
+++ b/api/routers/edr.py
@@ -118,15 +118,16 @@ async def get_locations(
             (obs.obs_mdata[-1].geo_point.lon, obs.obs_mdata[-1].geo_point.lat)
         )
         # Check for inconsistent parameter definitions between stations
-        # TODO: How to handle those?
-        if obs.ts_mdata.parameter_name in all_parameters and all_parameters[obs.ts_mdata.parameter_name] != parameter:
-            raise HTTPException(
-                status_code=500,
-                detail={
-                    "parameter": f"Parameter with name {obs.ts_mdata.parameter_name} "
-                    f"has multiple definitions:\n{all_parameters[obs.ts_mdata.parameter_name]}\n{parameter}"
-                },
-            )
+        # HACK: Avoid this error for now. We always return the last value found in /locations and collection metedata.
+        # Note that the correct UoM is always returned for a time series in the Coverage parameters.
+        # if obs.ts_mdata.parameter_name in all_parameters and all_parameters[obs.ts_mdata.parameter_name] != parameter:
+        #     raise HTTPException(
+        #         status_code=500,
+        #         detail={
+        #             "parameter": f"Parameter with name {obs.ts_mdata.parameter_name} "
+        #             f"has multiple definitions:\n{all_parameters[obs.ts_mdata.parameter_name]}\n{parameter}"
+        #         },
+        #     )
         all_parameters[obs.ts_mdata.parameter_name] = parameter
 
     # Check for multiple coordinates or names on one station

--- a/api/routers/edr.py
+++ b/api/routers/edr.py
@@ -117,17 +117,10 @@ async def get_locations(
         platform_coordinates[obs.ts_mdata.platform].add(
             (obs.obs_mdata[-1].geo_point.lon, obs.obs_mdata[-1].geo_point.lat)
         )
-        # Check for inconsistent parameter definitions between stations
-        # HACK: Avoid this error for now. We always return the last value found in /locations and collection metedata.
-        # Note that the correct UoM is always returned for a time series in the Coverage parameters.
-        # if obs.ts_mdata.parameter_name in all_parameters and all_parameters[obs.ts_mdata.parameter_name] != parameter:
-        #     raise HTTPException(
-        #         status_code=500,
-        #         detail={
-        #             "parameter": f"Parameter with name {obs.ts_mdata.parameter_name} "
-        #             f"has multiple definitions:\n{all_parameters[obs.ts_mdata.parameter_name]}\n{parameter}"
-        #         },
-        #     )
+        # There might be parameter inconsistencies (e.g one station is reporting in Pa, and another in hPa)
+        # We always return the "last" parameter definition found (in /locations and collection metadata).
+        # Note that the correct UoM is always returned in the Coverage parameters for the data endpoints.
+
         all_parameters[obs.ts_mdata.parameter_name] = parameter
 
     # Check for multiple coordinates or names on one station


### PR DESCRIPTION
A "Parameter" definition will be "randomly" picked for each variable in /locations and collection metadata endpoint, but the Coverage for the data endpoint will have the correct UoM for each timeseries.