### PR TITLE
Relocate platform check

### DIFF
--- a/ingest/src/ingest/bufr/ESOHBufr.h
+++ b/ingest/src/ingest/bufr/ESOHBufr.h
@@ -65,7 +65,7 @@ static std::map<DescriptorId, std::pair<std::string, std::string>> cf_names = {
 static std::string default_shadow_wigos("0-578-2024-");
 
 static std::list<std::pair<char, char>> repl_chars = {
-    {' ', '_'}, {'-', '_'}, {'\'', '_'}};
+    {' ', '_'}, {'-', '_'}, {'\'', 0}};
 
 class ESOHBufr : public NorBufr {
 
@@ -89,7 +89,7 @@ private:
                   char sensor_level_active, double sensor_level, std::string fn,
                   rapidjson::Document &) const;
   bool setPlatformName(std::string v, rapidjson::Document &message,
-                       bool force = true) const;
+                       bool force = true, bool filter = false) const;
   bool setPlatform(std::string v, rapidjson::Document &message) const;
   bool setLocation(double lat, double lon, double hei,
                    rapidjson::Document &) const;
@@ -101,7 +101,8 @@ private:
   bool setStartDateTime(struct tm *, rapidjson::Document &,
                         std::string period_str = "") const;
   WSI genShadowWigosId(std::list<Descriptor> &,
-                       std::list<Descriptor>::const_iterator &cir) const;
+                       std::list<Descriptor>::const_iterator &cir,
+                       bool filter = false) const;
 
   Oscar *oscar;
   std::string msg_template;

--- a/ingest/src/ingest/bufr/Makefile
+++ b/ingest/src/ingest/bufr/Makefile
@@ -10,7 +10,7 @@
 
 CXX := g++
 #CXX := clang++
-CXXFLAGS := -c -Wall -Wextra -O2 -std=c++17 -fPIC
+CXXFLAGS := -c -Wall -Wextra -O2 -std=c++20 -fPIC
 LDFLAGS := -shared
 
 .PHONY: clean all bufresohmsg_py

--- a/ingest/src/ingest/bufr/NorBufrIO.cpp
+++ b/ingest/src/ingest/bufr/NorBufrIO.cpp
@@ -207,7 +207,11 @@ void NorBufrIO::filterStr(std::string &s,
                           const std::list<std::pair<char, char>> &repl_chars) {
 
   for (auto rch : repl_chars) {
-    std::replace(s.begin(), s.end(), rch.first, rch.second);
+    if (rch.second) {
+      std::replace(s.begin(), s.end(), rch.first, rch.second);
+    } else {
+      std::erase(s, rch.first);
+    }
   }
 
   return;

--- a/ingest/src/ingest/bufr/NorBufrIO.cpp
+++ b/ingest/src/ingest/bufr/NorBufrIO.cpp
@@ -210,7 +210,11 @@ void NorBufrIO::filterStr(std::string &s,
     if (rch.second) {
       std::replace(s.begin(), s.end(), rch.first, rch.second);
     } else {
+#if __cplusplus >= 202002L
       std::erase(s, rch.first);
+#else
+      s.erase(std::remove(s.begin(), s.end(), rch.first), s.end());
+#endif
     }
   }
 


### PR DESCRIPTION
Platform check before the first meteorological descriptor, even if the value is missing.