### PR TITLE
Issue 178 levels filtering with combination

### DIFF
--- a/api/openapi/custom_dimension_examples.py
+++ b/api/openapi/custom_dimension_examples.py
@@ -36,6 +36,10 @@ levels = {
         "summary": "Open start range",
         "value": "../10.0",
     },
+    "Combination": {
+        "summary": "Combination",
+        "value": "1.0, 1.5/1.8, R5/2.0/2.0",
+    },
 }
 
 periods = {
@@ -53,6 +57,10 @@ periods = {
     "Wildcard": {
         "summary": "Open end range",
         "value": "PT0S/..",
+    },
+    "Combination": {
+        "summary": "Combination",
+        "value": "PT0S, PT1M/PT10M",
     },
 }
 

--- a/api/test/test_api_utilities.py
+++ b/api/test/test_api_utilities.py
@@ -1,0 +1,19 @@
+import pytest
+
+from utilities import get_levels_values
+
+levels_in_out = [
+    ("1", ["100"]),
+    ("1,2", ["100", "200"]),
+    ("1,2, 3", ["100", "200", "300"]),
+    ("1/3", ["100/300"]),
+    ("../3", ["../300"]),
+    ("1/..", ["100/.."]),
+    ("R3/1.2/0.3", ["120", "150", "180"]),
+    ("1, 3/5, R3/5/0.1,11", ["100", "300/500", "500", "510", "520", "1100"]),
+]
+
+
+@pytest.mark.parametrize("levels_in, levels_out", levels_in_out)
+def test_get_levels_values(levels_in, levels_out):
+    assert get_levels_values(levels_in) == levels_out

--- a/api/test/test_edr.py
+++ b/api/test/test_edr.py
@@ -410,3 +410,33 @@ def test_get_data_with_lowercase_period_range_without_existing_data():
 
         assert response.status_code == 404
         assert response.json() == {"detail": "Requested data not found."}
+
+
+def test_get_data_with_combination_levels_filtering():
+    with patch("routers.edr.get_obs_request") as mock_get_obs_request:
+
+        # Load with random test data for making a mock_obs_request
+        test_data = load_json("test/test_data/test_coverages_proto.json")
+        mock_get_obs_request.return_value = create_mock_obs_response(test_data)
+
+        response = client.get("/collections/observations/locations/0-20000-0-06260?levels=R6/0.0/0.1, 1.5/1.8, 10")
+
+        m_args = mock_get_obs_request.call_args[0][0]
+
+        assert response.status_code == 200
+        assert m_args.filter["level"].values == ["0", "10", "20", "30", "40", "50", "150/180", "1000"]
+
+
+def test_get_data_with_combination_periods_filtering():
+    with patch("routers.edr.get_obs_request") as mock_get_obs_request:
+
+        # Load with random test data for making a mock_obs_request
+        test_data = load_json("test/test_data/test_coverages_proto.json")
+        mock_get_obs_request.return_value = create_mock_obs_response(test_data)
+
+        response = client.get("/collections/observations/locations/0-20000-0-06260?periods=PT0S, PT1M/PT10M")
+
+        m_args = mock_get_obs_request.call_args[0][0]
+
+        assert response.status_code == 200
+        assert m_args.filter["period"].values == ["0", "60/600"]


### PR DESCRIPTION
Redo of #181 

Allow using multiple _ranges_ and multiple _repeating-intervals_ when filtering data with `levels` custom dimension. 
Using for example: 
- `/collections/observations/locations?levels=1.0/2.0, 8.0/10.0`
- `/collections/observations/locations?levels=0.0/1.5, 2.5, 10.0`

is possible after the merge.

/closes #178 