### PR TITLE
Fix typo in grpc config

### DIFF
--- a/api/grpc_getter.py
+++ b/api/grpc_getter.py
@@ -14,7 +14,12 @@ import grpc
 def get_grpc_stub():
     channel = grpc.aio.insecure_channel(
         f"{os.getenv('DSHOST', 'localhost')}:{os.getenv('DSPORT', '50050')}",
-        options=[("grpc.max_receive_message_length    ", int(os.getenv("GRPC_MAX_MESSAGE_SIZE", 4096)))],
+        options=[
+            (
+                "grpc.max_receive_message_length",
+                int(os.getenv("GRPC_MAX_MESSAGE_SIZE", 4096)),
+            )
+        ],
     )
     return dstore_grpc.DatastoreStub(channel)
 

--- a/api/grpc_getter.py
+++ b/api/grpc_getter.py
@@ -17,7 +17,7 @@ def get_grpc_stub():
         options=[
             (
                 "grpc.max_receive_message_length",
-                int(os.getenv("GRPC_MAX_MESSAGE_SIZE", 4096)),
+                int(os.getenv("GRPC_MAX_MESSAGE_SIZE", 4194304)),
             )
         ],
     )


### PR DESCRIPTION
There was some extra spaces in the grpc.max_receive_message_length that seem to break the configuration of this property.